### PR TITLE
Updates Dockerfiles for EMC wrapper due to deleted algoritm-base image

### DIFF
--- a/v6_wrapper/EMC/Dockerfile
+++ b/v6_wrapper/EMC/Dockerfile
@@ -3,7 +3,8 @@
 # different image here (e.g. python:3). In that case it is important that
 # `vantage6-client` is a dependancy of you project as this contains the wrapper
 # we are using in this example.
-FROM harbor.vantage6.ai/algorithms/algorithm-base
+# FROM harbor.vantage6.ai/algorithms/algorithm-base
+FROM pmateus/algorithm-base:1.0.0
 
 # Change this to the package name of your project. This needs to be the same
 # as what you specified for the name in the `setup.py`.
@@ -13,13 +14,14 @@ RUN apt-get update
 RUN apt-get install -y wget tar ssh
 
 # This will install your algorithm into this image.
-COPY . /app
+COPY v6_wrapper/EMC /app
 RUN pip install -r app/requirements.txt
 RUN pip install --no-cache-dir /app
 
 # Copy ssh key and host key into container
-COPY id_rsa known_hosts /root/.ssh/
-COPY connection_settings.json /root/
+COPY v6_wrapper/EMC/id_rsa /root/.ssh/id_rsa
+COPY v6_wrapper/EMC/known_hosts /root/.ssh/known_hosts
+COPY v6_wrapper/EMC/connection_settings.json /root/connection_settings.json
 
 # This will run your algorithm when the Docker container is started. The
 # wrapper takes care of the IO handling (communication between node and

--- a/v6_wrapper/EMC/Dockerfile.master
+++ b/v6_wrapper/EMC/Dockerfile.master
@@ -3,7 +3,8 @@
 # different image here (e.g. python:3). In that case it is important that
 # `vantage6-client` is a dependancy of you project as this contains the wrapper
 # we are using in this example.
-FROM harbor.vantage6.ai/algorithms/algorithm-base
+# FROM harbor.vantage6.ai/algorithms/algorithm-base
+FROM pmateus/algorithm-base:1.0.0
 
 # Change this to the package name of your project. This needs to be the same
 # as what you specified for the name in the `setup.py`.
@@ -14,17 +15,17 @@ RUN apt-get install -y apt-utils gcc libpq-dev wget tar
 RUN apt-get install -y wget tar ssh
 
 # This will install your algorithm into this image.
-COPY . /app
+COPY v6_wrapper/EMC /app
 RUN pip install -r app/requirements_master.txt
-COPY ../../. app-brain-age
-RUN pip install -r app-brain-age/requirements.txt
+COPY . app-brain-age
 
 RUN pip install --no-cache-dir /app-brain-age
 RUN pip install --no-cache-dir /app
 
 # Copy ssh key and host key into container
-COPY id_rsa known_hosts /root/.ssh/
-COPY connection_settings.json /root/
+COPY v6_wrapper/EMC/id_rsa /root/.ssh/id_rsa
+COPY v6_wrapper/EMC/known_hosts /root/.ssh/known_hosts
+COPY v6_wrapper/EMC/connection_settings.json /root/connection_settings.json
 
 # This will run your algorithm when the Docker container is started. The
 # wrapper takes care of the IO handling (communication between node and

--- a/v6_wrapper/EMC/README.md
+++ b/v6_wrapper/EMC/README.md
@@ -21,11 +21,15 @@ Copy the host fingerprint into the known_hosts file and fill in the connection_s
 }
 ```
 
-Then build the docker image:
+Then build the docker images by running the following commands from the root of the repository:
 ```bash 
-chmod 600 id_rsa
-docker build . --tag vantage6_slurm:0.1.0
+chmod 600 ./v6_wrapper/EMC/id_rsa
+docker build --tag vantage6_slurm:0.1.0 -f v6_wrapper/EMC/Dockerfile .
+docker build --tag vantage6_slurm_master:0.1.0 -f v6_wrapper/EMC/Dockerfile.master .
 ```
+
+Using the image from Dockerfile.master will allow you to use a node as a master node as well as a regular node. 
+The image from the other Dockerfile only allows the node to operate as a non-master node.
 
 Make the node configuration as usual then add the following section to the relevant environment:
 
@@ -36,7 +40,7 @@ environments:
     test:
         ...
         docker_images_placeholders:
-            gpu_image: vantage6_slurm:0.1.0
+            gpu_image: vantage6_slurm:0.1.0 # Or vantage6_slurm_master:0.1.0
 ```
 
 In order for this to work, you will need a special version of vantage6-node: pmateus/vantage6-node-whitelisted:2.0.0 


### PR DESCRIPTION
It was pointed out that the original algorithm-base image is no longer available from the Vantage6 Harbor. I replaced their occurances with a mirrored version, pmateus/algorithm-base:1.0.0.